### PR TITLE
Rename "prepublish" script to "prepare" to allow using the package from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint src/*.js test/*.js",
     "lint-fix": "npm run lint -- --fix",
     "compile": "babel src --out-dir dist",
-    "prepublish": "npm run compile",
+    "prepare": "npm run compile",
     "pretest-unit": "npm run compile",
     "test": "npm run lint && npm run test-unit",
     "test-unit": "electron-mocha ./test --recursive --compilers js:babel-core/register --timeout 60000 -R spec-xunit-file -r test/setup.js"


### PR DESCRIPTION
Allows for the following when using `yarn`:

`package.json`
```json
{
  "devDependencies": {
    "electron-devtools-installer": "git+https://github.com/MOZGIII/electron-devtools-installer.git#prepare-script"
  }
}
```

This setup allows using the package directly from `git` to avoid blocking on release.